### PR TITLE
B1505 multiformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "common-spectrum": "^0.19.0",
-    "ndim-parser": "^0.3.0"
+    "ndim-parser": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -47,18 +47,18 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "common-spectrum": "^0.18.2",
-    "ndim-parser": "^0.2.0"
+    "common-spectrum": "^0.19.0",
+    "ndim-parser": "^0.3.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "cheminfo-build": "^1.1.9",
-    "eslint": "^7.19.0",
-    "eslint-config-cheminfo-typescript": "^8.0.5",
+    "eslint": "^7.20.0",
+    "eslint-config-cheminfo-typescript": "^8.0.6",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
-    "ts-jest": "^26.5.0",
-    "typescript": "^4.1.3"
+    "ts-jest": "^26.5.1",
+    "typescript": "^4.1.5"
   }
 }

--- a/src/from/__tests__/fromCVd.test.ts
+++ b/src/from/__tests__/fromCVd.test.ts
@@ -11,11 +11,11 @@ test('fromCVd', () => {
   let analysis = fromCVd(csv);
   let spectrum = analysis.getXYSpectrum({ index: 0 });
 
-  expect(spectrum.variables.x.data).toHaveLength(1001);
+  expect(spectrum.variables.x.data).toHaveLength(1000);
   expect(spectrum.variables.x.label).toStrictEqual('Vd');
 
-  expect(spectrum.variables.y.data).toHaveLength(1001);
-  expect(spectrum.variables.y.label).toStrictEqual('C dens');
+  expect(spectrum.variables.y.data).toHaveLength(1000);
+  expect(spectrum.variables.y.label).toStrictEqual('C_dens');
 
   expect(spectrum.title).toBe('Cdg-V_high_voltage');
 });

--- a/src/from/b1505/BaseB1505.ts
+++ b/src/from/b1505/BaseB1505.ts
@@ -65,7 +65,7 @@ export default class BaseB1505 {
 
   public parseText(text: string) {
     const series = appendedParser(text);
-    let analyses = new Array(series.length);
+    let analyses = [];
 
     for (const serie of series) {
       const { data, meta } = serie;
@@ -74,7 +74,10 @@ export default class BaseB1505 {
 
       let analysis = new Analysis();
       analysis.pushSpectrum(appendUnits(data, knownUnits), {
-        title: parsedMeta['Setup title'] || parsedMeta.SetupTitle,
+        title:
+          parsedMeta['TestRecord.Remarks'] ||
+          parsedMeta['Setup title'] ||
+          parsedMeta.SetupTitle,
         meta: parsedMeta,
       });
       analyses.push(analysis);

--- a/src/from/b1505/BaseB1505.ts
+++ b/src/from/b1505/BaseB1505.ts
@@ -1,5 +1,5 @@
 import { Analysis } from 'common-spectrum';
-import { ndParse } from 'ndim-parser';
+import { appendedParser } from 'ndim-parser';
 
 import { appendUnits, toNumber } from '../../utils';
 
@@ -12,7 +12,6 @@ type Scales = 'linear' | 'log';
 export default class BaseB1505 {
   private readonly xLabel: string;
   private readonly yLabel: string;
-  private readonly isTagged: boolean;
   private readonly scale: Scales;
 
   private readonly metaVarHeaders = [
@@ -22,15 +21,9 @@ export default class BaseB1505 {
     'Function.User',
   ];
 
-  public constructor(
-    xLabel: string,
-    yLabel: string,
-    isTagged: boolean,
-    scale: Scales,
-  ) {
+  public constructor(xLabel: string, yLabel: string, scale: Scales) {
     this.xLabel = xLabel;
     this.yLabel = yLabel;
-    this.isTagged = isTagged;
     this.scale = scale;
   }
 
@@ -48,7 +41,8 @@ export default class BaseB1505 {
     }
 
     // add default kind scale
-    ans.scale = this.scale;
+    const { xLabel, yLabel, scale } = this;
+    ans.defaults = { xLabel, yLabel, scale };
 
     return ans;
   }
@@ -69,26 +63,23 @@ export default class BaseB1505 {
     return knownUnits;
   }
 
-  private keyMap(keys: string[]) {
-    return keys.map((key, index) => {
-      if (key === this.xLabel) return 'x';
-      if (key === this.yLabel) return 'y';
-      return String.fromCharCode(65 + index);
-    });
-  }
-
   public parseText(text: string) {
-    const keyMap = this.keyMap.bind(this);
-    const { data, meta } = ndParse(text, { keyMap, isTagged: this.isTagged });
-    const parsedMeta = this.parseMeta(meta);
-    const knownUnits = this.metaUnits(meta);
+    const series = appendedParser(text);
+    let analyses = new Array(series.length);
 
-    let analysis = new Analysis();
-    analysis.pushSpectrum(appendUnits(data, knownUnits), {
-      title: parsedMeta['Setup title'] || parsedMeta.SetupTitle,
-      meta: parsedMeta,
-    });
+    for (const serie of series) {
+      const { data, meta } = serie;
+      const parsedMeta = this.parseMeta(meta);
+      const knownUnits = this.metaUnits(meta);
 
-    return analysis;
+      let analysis = new Analysis();
+      analysis.pushSpectrum(appendUnits(data, knownUnits), {
+        title: parsedMeta['Setup title'] || parsedMeta.SetupTitle,
+        meta: parsedMeta,
+      });
+      analyses.push(analysis);
+    }
+
+    return analyses;
   }
 }

--- a/src/from/b1505/__tests__/fromB1505.test.ts
+++ b/src/from/b1505/__tests__/fromB1505.test.ts
@@ -15,141 +15,88 @@ import {
 
 function testFile(
   name: string,
-  title: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   func: (text: string) => any,
-  xLabel: string,
-  yLabel: string,
   length: number,
 ) {
   let csv = readFileSync(
     join(__dirname, `../../../../testFiles/B1505/${name}`),
     'latin1',
   );
-  let analysis = func(csv);
-  let spectrum = analysis.getXYSpectrum({ index: 0 });
+  let analyses = func(csv);
+  for (const analysis of analyses) {
+    const { xLabel, yLabel } = analysis.spectra[0].meta.defaults;
+    let spectrum = analysis.getXYSpectrum({ xLabel, yLabel });
 
-  expect(spectrum.variables.x.data).toHaveLength(length);
-  expect(spectrum.variables.x.label).toStrictEqual(xLabel);
+    expect(spectrum.variables.x.data).toHaveLength(length);
+    expect(spectrum.variables.x.label).toStrictEqual(xLabel);
 
-  expect(spectrum.variables.y.data).toHaveLength(length);
-  expect(spectrum.variables.y.label).toStrictEqual(yLabel);
-
-  expect(spectrum.title).toBe(title);
+    expect(spectrum.variables.y.data).toHaveLength(length);
+    expect(spectrum.variables.y.label).toStrictEqual(yLabel);
+  }
 }
 
 describe('Breakdown', () => {
   it('Breakdown', () => {
-    testFile(
-      'Breakdown/breakdown.csv',
-      'Breakdown',
-      fromBreakdown,
-      'Vd',
-      'Id dens',
-      120,
+    testFile('Breakdown/breakdown.csv', fromBreakdown, 119);
+  });
+
+  it('Multiple breakdown', () => {
+    let csv = readFileSync(
+      join(
+        __dirname,
+        '../../../../testFiles/B1505/Breakdown/multiple_breakdown.csv',
+      ),
+      'latin1',
     );
+    let analyses = fromBreakdown(csv);
+    expect(analyses).toHaveLength(164);
   });
 
   it('HEMT Breakdown', () => {
-    testFile(
-      'Breakdown/HEMT_breakdown.csv',
-      'HEMT Breakdown',
-      fromHEMTBreakdown,
-      'Vd',
-      'Id density',
-      408,
-    );
+    testFile('Breakdown/HEMT_breakdown.csv', fromHEMTBreakdown, 407);
   });
 });
 
 describe('Capacitance', () => {
   it('High voltage', () => {
-    testFile(
-      'Capacitance/high_voltage.csv',
-      'Cdg-V_high_voltage',
-      fromCapacitance,
-      'Vd',
-      'C dens',
-      1001,
-    );
+    testFile('Capacitance/high_voltage.csv', fromCapacitance, 1000);
   });
 
   it('MOS capacitance', () => {
-    testFile(
-      'Capacitance/mos_cap.csv',
-      'MOS cap measurement',
-      fromMOSCapacitance,
-      'VBias',
-      'C density',
-      1001,
-    );
+    testFile('Capacitance/mos_cap.csv', fromMOSCapacitance, 1000);
   });
 });
 
 test('IV', () => {
-  testFile('IV/sweep.csv', 'I/V Sweep', fromIV, 'Vd', 'Id dens', 201);
-  testFile(
-    'IV/sweep_diode.csv',
-    'I/V Sweep diode ON',
-    fromIV,
-    'Vd',
-    'Id dens',
-    201,
-  );
+  testFile('IV/sweep.csv', fromIV, 200);
+  testFile('IV/sweep_diode.csv', fromIV, 200);
 });
 
 describe('Output', () => {
   it('F implant', () => {
-    testFile(
-      'Output/f_implant.csv',
-      'Output',
-      fromOutput,
-      'Vd',
-      'Id dens',
-      3208,
-    );
+    testFile('Output/f_implant.csv', fromOutput, 3207);
   });
 
   it('lpcvd', () => {
-    testFile('Output/lpcvd.csv', 'Output', fromOutput, 'Vd', 'Id dens', 201);
+    testFile('Output/lpcvd.csv', fromOutput, 200);
   });
 
   it('noff trigate', () => {
-    testFile(
-      'Output/noff_trigate.csv',
-      'output',
-      fromNoffOutput,
-      'Vd',
-      'Id density',
-      301,
-    );
+    testFile('Output/noff_trigate.csv', fromNoffOutput, 300);
   });
 
   it('Output', () => {
-    testFile('Output/output.csv', 'Output', fromOutput, 'Vd', 'Id dens', 201);
+    testFile('Output/output.csv', fromOutput, 200);
   });
 });
 
 describe('Transfer', () => {
   it('HEMT transfer', () => {
-    testFile(
-      'Transfer/hemt_transfer.csv',
-      'HEMT_transfer',
-      fromTransfer,
-      'Vg',
-      'Id dens',
-      201,
-    );
+    testFile('Transfer/hemt_transfer.csv', fromTransfer, 200);
   });
 
   it('noff trigate', () => {
-    testFile(
-      'Transfer/noff_trigate.csv',
-      'Transfer',
-      fromNoffTransfer,
-      'Vg',
-      'Id density',
-      201,
-    );
+    testFile('Transfer/noff_trigate.csv', fromNoffTransfer, 200);
   });
 });

--- a/src/from/b1505/index.ts
+++ b/src/from/b1505/index.ts
@@ -1,37 +1,46 @@
 import BaseB1505 from './BaseB1505';
 
+interface Options {
+  xLabel: string;
+  yLabel: string;
+  scale: 'linear' | 'log';
+}
+export function fromB1505(text: string, { xLabel, yLabel, scale }: Options) {
+  return new BaseB1505(xLabel, yLabel, scale).parseText(text);
+}
+
 export function fromBreakdown(text: string) {
-  return new BaseB1505('Vd', 'Id_dens', true, 'log').parseText(text);
+  return new BaseB1505('Vd', 'Id_dens', 'log').parseText(text);
 }
 
 export function fromHEMTBreakdown(text: string) {
-  return new BaseB1505('Vd', 'Id_density', true, 'log').parseText(text);
+  return new BaseB1505('Vd', 'Id_density', 'log').parseText(text);
 }
 
 export function fromTransfer(text: string) {
-  return new BaseB1505('Vg', 'Id_dens', true, 'log').parseText(text);
+  return new BaseB1505('Vg', 'Id_dens', 'log').parseText(text);
 }
 
 export function fromNoffTransfer(text: string) {
-  return new BaseB1505('Vg', 'Id_density', true, 'log').parseText(text);
+  return new BaseB1505('Vg', 'Id_density', 'log').parseText(text);
 }
 
 export function fromOutput(text: string) {
-  return new BaseB1505('Vd', 'Id_dens', true, 'linear').parseText(text);
+  return new BaseB1505('Vd', 'Id_dens', 'linear').parseText(text);
 }
 
 export function fromNoffOutput(text: string) {
-  return new BaseB1505('Vd', 'Id_density', true, 'linear').parseText(text);
+  return new BaseB1505('Vd', 'Id_density', 'linear').parseText(text);
 }
 
 export function fromIV(text: string) {
-  return new BaseB1505('Vd', 'Id_dens', true, 'linear').parseText(text);
+  return new BaseB1505('Vd', 'Id_dens', 'linear').parseText(text);
 }
 
 export function fromCapacitance(text: string) {
-  return new BaseB1505('Vd', 'C_dens', false, 'linear').parseText(text);
+  return new BaseB1505('Vd', 'C_dens', 'linear').parseText(text);
 }
 
 export function fromMOSCapacitance(text: string) {
-  return new BaseB1505('VBias', 'C_density', true, 'linear').parseText(text);
+  return new BaseB1505('VBias', 'C_density', 'linear').parseText(text);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,5 +27,7 @@ export { fromMulChannelCap } from './from/fromMulChannelCap';
 export function fromCVd(text: string) {
   // eslint-disable-next-line no-console
   console.warn('Deprecated: use fromCapacitance instead');
-  return fromCapacitance(text);
+  const list = fromCapacitance(text);
+  if (list.length !== 1) throw new Error("Series doesn't found");
+  return list[0];
 }


### PR DESCRIPTION
- updates  `common-spectrum` and `ndim-parser`
- supports and test multidimensional files
- exports general b1505 parser
- doesn't need to specify if the file is tagged